### PR TITLE
Jw/validate repayment address length

### DIFF
--- a/cosmwasm/contracts/fast-transfer-gateway/src/error.rs
+++ b/cosmwasm/contracts/fast-transfer-gateway/src/error.rs
@@ -50,6 +50,9 @@ pub enum ContractError {
 
     #[error("Duplicate order")]
     DuplicateOrder,
+
+    #[error("Invalid repayment address")]
+    InvalidRepaymentAddress,
 }
 
 pub type ContractResult<T> = Result<T, ContractError>;

--- a/cosmwasm/contracts/fast-transfer-gateway/src/execute.rs
+++ b/cosmwasm/contracts/fast-transfer-gateway/src/execute.rs
@@ -92,6 +92,10 @@ pub fn initiate_settlement(
 ) -> ContractResponse {
     let config = CONFIG.load(deps.storage)?;
 
+    if repayment_address.len() != 32 {
+        return Err(ContractError::InvalidRepaymentAddress);
+    }
+
     let mut fills_to_settle = Vec::new();
 
     for order_id in &order_ids {

--- a/cosmwasm/contracts/fast-transfer-gateway/tests/test_initiate_settlement.rs
+++ b/cosmwasm/contracts/fast-transfer-gateway/tests/test_initiate_settlement.rs
@@ -152,6 +152,40 @@ fn test_initiate_settlement_multiple_orders() {
 }
 
 #[test]
+fn test_initiate_settlement_fails_if_repayment_address_is_invalid() {
+    let (mut deps, env) = default_instantiate();
+
+    let solver_address = deps.api.with_prefix("osmo").addr_make("solver");
+
+    let order_id = HexBinary::from_hex("1234").unwrap();
+
+    state::order_fills()
+        .create_order_fill(
+            deps.as_mut().storage,
+            order_id.clone(),
+            solver_address.clone(),
+            2,
+        )
+        .unwrap();
+
+    let execute_msg = ExecuteMsg::InitiateSettlement {
+        order_ids: vec![order_id],
+        repayment_address: HexBinary::from(left_pad_bytes(
+            bech32_decode(solver_address.as_str()).unwrap(),
+            64,
+        )),
+    };
+
+    let info = mock_info(solver_address.as_str(), &[]);
+
+    let res = go_fast_transfer_cw::contract::execute(deps.as_mut(), env, info, execute_msg.clone())
+        .unwrap_err()
+        .to_string();
+
+    assert_eq!(res, "Invalid repayment address");
+}
+
+#[test]
 fn test_initiate_settlement_fails_if_sender_is_not_filler() {
     let (mut deps, env) = default_instantiate();
 

--- a/cosmwasm/package-lock.json
+++ b/cosmwasm/package-lock.json
@@ -17,7 +17,7 @@
         "viem": "^2.19.4"
       },
       "devDependencies": {
-        "@tsconfig/recommended": "^1.0.6",
+        "@tsconfig/recommended": "^1.0.13",
         "@types/node": "^20.12.11",
         "dotenv": "^16.4.5"
       }
@@ -286,10 +286,11 @@
       }
     },
     "node_modules/@tsconfig/recommended": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.6.tgz",
-      "integrity": "sha512-0IKu9GHYF1NGTJiYgfWwqnOQSlnE9V9R7YohHNNf0/fj/SyOZWzdd06JFr0fLpg1Mqw0kGbYg8w5xdkSqLKM9g==",
-      "dev": true
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.13.tgz",
+      "integrity": "sha512-sySRuBfMKyKO/j2ZAhR8kSembhjuPEV4Ra3AHtmWLq51+iGaudr45crPSzNC5b7/Ctrh9dfUpBuTlYrH6rM58Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -830,6 +831,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/cosmwasm/package.json
+++ b/cosmwasm/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@tsconfig/recommended": "^1.0.6",
+    "@tsconfig/recommended": "^1.0.13",
     "@types/node": "^20.12.11",
     "dotenv": "^16.4.5"
   },

--- a/cosmwasm/scripts/migrate.ts
+++ b/cosmwasm/scripts/migrate.ts
@@ -5,12 +5,12 @@ import { GasPrice } from "@cosmjs/stargate";
 import { fromBech32 } from "@cosmjs/encoding";
 import { instantiateContract, migrateContract, storeContract } from "./lib";
 
-const GAS_PRICE = GasPrice.fromString("0.025uosmo");
+const GAS_PRICE = GasPrice.fromString("0.1uosmo");
 const CHAIN_PREFIX = "osmo";
 const RPC_URL = "https://osmosis-rpc.polkachu.com";
 
 const CONTRACT_ADDRESS =
-  "osmo1cnze5c4y7jw69ghzczsnu9v9qz3xuvevw5ayr2g0pa3ayafumlusej3pf5";
+  "osmo1vy34lpt5zlj797w7zqdta3qfq834kapx88qtgudy7jgljztj567s73ny82";
 
 async function main() {
   const DEPLOYER_MNEMONIC = process.env.DEPLOYER_MNEMONIC;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enforces a 32-byte repayment address in `initiate_settlement`, adds a failing-test case for invalid addresses, and updates deployment script configs.
> 
> - **Smart Contract (`fast-transfer-gateway`)**:
>   - Add `ContractError::InvalidRepaymentAddress` in `src/error.rs`.
>   - Validate `repayment_address` length (`== 32`) in `execute::initiate_settlement` and return `InvalidRepaymentAddress` on failure.
>   - Tests: add `test_initiate_settlement_fails_if_repayment_address_is_invalid`.
> - **Scripts**:
>   - Update `scripts/migrate.ts`: set `GAS_PRICE` to `0.1uosmo` and change `CONTRACT_ADDRESS`.
> - **Dev tooling**:
>   - Bump `@tsconfig/recommended` to `^1.0.13`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d39ef04cf2a18ff152c584af74e3d0bba66c027c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->